### PR TITLE
Implementation of School/Department list components

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -19,7 +19,12 @@
       "testTsconfig": "tsconfig.spec.json",
       "prefix": "app",
       "styles": [
-        "styles.scss"
+        "styles.scss",
+        "./assets/styles/open_sans_300.css",
+        "./assets/styles/open_sans_400.css",
+        "./assets/styles/open_sans_600.css",
+        "./assets/styles/open_sans_700.css",
+        "./assets/styles/open_sans_800.css"
       ],
       "scripts": [
       ],

--- a/src/_mixins.scss
+++ b/src/_mixins.scss
@@ -1,0 +1,3 @@
+$font: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+$yacs_bgs: #C65353;
+

--- a/src/_vars.scss
+++ b/src/_vars.scss
@@ -1,0 +1,3 @@
+$font: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+$yacs_bgs: #C65353;
+

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,0 +1,29 @@
+header-bar {
+  width:100%;
+  height:50px;
+  position:fixed;
+  z-index: 1;
+  color: white;
+  background-color: #c65353;
+  white-space: nowrap;
+}
+
+div#content {
+  padding: 60px 15px 0px 15px;
+}
+
+img#loading {
+  position:absolute;
+  top: 50%;
+  left: 50%;
+  /* browsers handle fractional pixel values differently, but the worst that
+     can happen is that it's 1/2 pixel off center. So it's best to use the
+     real values (half of the image width and height) here. */
+  margin-top: -4.5px;
+  margin-left: -62.5px;
+}
+
+footer {
+  margin: 0px auto;
+  max-width: 950px;
+}

--- a/src/app/footer/component.html
+++ b/src/app/footer/component.html
@@ -1,14 +1,17 @@
+
 <div class="footer-column">
-  <div class="flavortext">
-    {{flavortext}} <a href="https://rcos.io">RCOS</a> project.
-  </div>
-  <a href="/about">Learn more about YACS.</a>
+	<div class="flavortext">
+	  {{flavortext}} <a href="https://rcos.io">RCOS</a> project.
+	</div>
+	<a href="/about">Learn more about YACS.</a>
 </div>
 <div class="footer-column">
-  <div class="version">YACS 0.10 - Angular</div>
-  <div class="feedback">
-    We love feedback!
-    <a href="github.com/yacs-rcos/yacs/issues" target="_blank">Github</a> | 
-    <a href="mailto:yacsrpi@gmail.com">Email</a>
-  </div>
+	<div class="version">YACS 0.10 - Angular</div>
+	<div class="feedback">
+	  We love feedback!
+	  <a href="github.com/yacs-rcos/yacs/issues" target="_blank">Github</a>
+	  |
+	  <a href="mailto:yacsrpi@gmail.com">Email the devs</a>
+	</div>
 </div>
+

--- a/src/app/footer/component.html
+++ b/src/app/footer/component.html
@@ -1,10 +1,14 @@
-<div class="flavortext">
-  {{flavortext}} <a href="https://rcos.io">RCOS</a> project.
+<div class="footer-column">
+  <div class="flavortext">
+    {{flavortext}} <a href="https://rcos.io">RCOS</a> project.
+  </div>
+  <a href="/about">Learn more about YACS.</a>
 </div>
-<a href="/about">Learn more about YACS.</a>
-<div class="version">YACS 0.10 - Angular</div>
-<div class="feedback">
-  We love feedback!
-  <a href="github.com/yacs-rcos/yacs/issues" target="_blank">Github</a>
-  <a href="mailto:yacsrpi@gmail.com">Email</a>
+<div class="footer-column">
+  <div class="version">YACS 0.10 - Angular</div>
+  <div class="feedback">
+    We love feedback!
+    <a href="github.com/yacs-rcos/yacs/issues" target="_blank">Github</a> | 
+    <a href="mailto:yacsrpi@gmail.com">Email</a>
+  </div>
 </div>

--- a/src/app/footer/component.scss
+++ b/src/app/footer/component.scss
@@ -1,0 +1,13 @@
+a {
+  color: #d57f7f;
+}
+
+.footer-column {
+  float: left;
+  width: 50%;
+  color: #afafaf;
+}
+
+.footer-column:last-child {
+  text-align: right;
+}

--- a/src/app/footer/component.scss
+++ b/src/app/footer/component.scss
@@ -1,13 +1,17 @@
-a {
-  color: #d57f7f;
-}
+@import "../../_vars.scss";
 
 .footer-column {
-  float: left;
-  width: 50%;
-  color: #afafaf;
+    font-family: $font;
+    font-weight: 300;
+    float: left;
+    width: 50%;
+    color: #AFAFAF;
+    &:last-child {
+        text-align: right;
+    }
+    a {
+        text-decoration:none;
+        color: #D57F7F;
+    }
 }
 
-.footer-column:last-child {
-  text-align: right;
-}

--- a/src/app/footer/component.ts
+++ b/src/app/footer/component.ts
@@ -49,7 +49,8 @@ const FLAVORTEXTS: string[] = [
 
 @Component({
   selector: 'footer',
-  templateUrl: './component.html'
+  templateUrl: './component.html',
+  styleUrls: ['./component.scss']
 })
 
 export class FooterComponent {

--- a/src/app/footer/component.ts
+++ b/src/app/footer/component.ts
@@ -50,7 +50,7 @@ const FLAVORTEXTS: string[] = [
 @Component({
   selector: 'footer',
   templateUrl: './component.html',
-  styleUrls: ['./component.scss']
+  styleUrls: ['component.scss']
 })
 
 export class FooterComponent {

--- a/src/app/header/component.html
+++ b/src/app/header/component.html
@@ -1,16 +1,17 @@
-<nav>
+<nav id="headerbar">
   <table id="navtable">
-    <tbody>
-      <tr>
-        <td class="sidelink" id="page-title"><a href="/">YACS <span class="sub">beta</span></a></td>
-        <td>
-          <span id="searchcontainer">
-            <img id="searchglyph" src="/assets/images/search.svg">
-            <input id="searchbar" placeholder="Search Fall 2017">
-          </span>
-        </td>
-        <td class="sidelink" id="schedule-btn"><a href="/schedules">Schedules</a></td>
-      </tr>
-    </tbody>
+    <tr>
+      <td class="sidelink" id="page-title">
+        <a href="/">YACS <span class="sub">beta</span></a>
+      <td>
+        <span id="searchcontainer">
+          <img id="searchglyph" src="assets/images/search.svg"/>
+          <input id="searchbar" placeholder="Search Fall 2017"/>
+        </span>
+      </td>
+      <td class="sidelink" id="schedule-btn">
+        <a href="/schedules">Schedule</a>
+      </td>
+    </tr>
   </table>
 </nav>

--- a/src/app/header/component.html
+++ b/src/app/header/component.html
@@ -1,8 +1,16 @@
 <nav>
-  <a href="/">YACS <span class="sub">beta</span></a>
-  <div id="searchcontainer">
-    <img src="/assets/images/search.svg" style="width:50px">
-    <input placeholder="Search Fall 2017">
-  </div>
-  <a href="/schedules">Schedules</a>
+  <table id="navtable">
+    <tbody>
+      <tr>
+        <td class="sidelink" id="page-title"><a href="/">YACS <span class="sub">beta</span></a></td>
+        <td>
+          <span id="searchcontainer">
+            <img id="searchglyph" src="/assets/images/search.svg">
+            <input id="searchbar" placeholder="Search Fall 2017">
+          </span>
+        </td>
+        <td class="sidelink" id="schedule-btn"><a href="/schedules">Schedules</a></td>
+      </tr>
+    </tbody>
+  </table>
 </nav>

--- a/src/app/header/component.scss
+++ b/src/app/header/component.scss
@@ -1,64 +1,88 @@
+@import "../../_vars.scss";
+
+nav#headerbar {
+    width:100%;
+    height:50px;
+    position:fixed;
+    z-index: 1;
+    font-family: $font;  
+    font-weight: 300;  
+    background-color: $yacs_bgs;
+    white-space: nowrap;
+}
+
 table#navtable {
     width:100%;
     height:100%;
     border-collapse:collapse;
+    td {
+        text-align:center;
+        vertical-align:middle;
+    }
 }
-table#navtable td {
-    text-align:center;
-    vertical-align:middle;
-}
-table#navtable td.sidelink {
+
+.sidelink {
     width:160px;
     cursor:pointer;
+    a {
+        color: #FFFFFF;
+        text-decoration:none;
+    } 
 }
+
 #page-title {
-    font-size:35px;
-    font-weight:300;
+    font-size: 35px;
+    span.sub{
+        font-size:16px;
+    }
 }
-#page-title span.sub {
-    font-size:16px;
-}
+
 #search {
     margin:auto;
 }
 
-#searchbar::-webkit-input-placeholder { /* Chrome/Opera/Safari */
-  color: #fafafa;
-}
-#searchbar::-moz-placeholder { /* Firefox 19+ */
-  color: #fafafa;
-}
-#searchbar:-ms-input-placeholder { /* IE 10+ */
-  color: #fafafa;
-}
-
 #searchcontainer {
-    font-family: "Open Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-family: $font;
+    font-weight: 300;
     font-size: 18px;
     color: white;
     background-color: #d57f7f;
     border-radius: 2px;
     width: 100%;
     padding: 3px 4px;
+    margin:auto;
+
 }
+
 #searchbar {
-    /* font needs to be specified again for some reason, I think it's
-       something to do with the input tag? */
-    font-family: inherit;
+    font-family: $font;
+    font-weight: 300;
     font-size: 18px;
     max-width: 20em;
-    font-weight: 300;
     border: none;
     width: 100%;
     background-color: inherit;
     color: inherit;
     outline: none;
+    &::-ms-input-placeholder {
+        color: #FFFFFF;
+
+    }
+    &::-moz-placeholder{
+        color: #FFFFFF;
+
+    } 
+    &::-webkit-input-placeholder {
+        color: #FFFFFF;
+    }
 }
+
 #searchglyph {
     height: 1em;
     vertical-align: sub;
     padding: 0.1em;
 }
+
 #schedule-btn {
     font-size:22px;
 }

--- a/src/app/header/component.scss
+++ b/src/app/header/component.scss
@@ -1,0 +1,64 @@
+table#navtable {
+    width:100%;
+    height:100%;
+    border-collapse:collapse;
+}
+table#navtable td {
+    text-align:center;
+    vertical-align:middle;
+}
+table#navtable td.sidelink {
+    width:160px;
+    cursor:pointer;
+}
+#page-title {
+    font-size:35px;
+    font-weight:300;
+}
+#page-title span.sub {
+    font-size:16px;
+}
+#search {
+    margin:auto;
+}
+
+#searchbar::-webkit-input-placeholder { /* Chrome/Opera/Safari */
+  color: #fafafa;
+}
+#searchbar::-moz-placeholder { /* Firefox 19+ */
+  color: #fafafa;
+}
+#searchbar:-ms-input-placeholder { /* IE 10+ */
+  color: #fafafa;
+}
+
+#searchcontainer {
+    font-family: "Open Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
+    font-size: 18px;
+    color: white;
+    background-color: #d57f7f;
+    border-radius: 2px;
+    width: 100%;
+    padding: 3px 4px;
+}
+#searchbar {
+    /* font needs to be specified again for some reason, I think it's
+       something to do with the input tag? */
+    font-family: inherit;
+    font-size: 18px;
+    max-width: 20em;
+    font-weight: 300;
+    border: none;
+    width: 100%;
+    background-color: inherit;
+    color: inherit;
+    outline: none;
+}
+#searchglyph {
+    height: 1em;
+    vertical-align: sub;
+    padding: 0.1em;
+}
+#schedule-btn {
+    font-size:22px;
+}

--- a/src/app/header/component.ts
+++ b/src/app/header/component.ts
@@ -4,9 +4,10 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'header-bar',
   templateUrl: './component.html',
-  styleUrls: ['./component.scss']
+  styleUrls: ['component.scss']
 })
 
 export class HeaderComponent {
   searchText = '';
+
 }

--- a/src/app/header/component.ts
+++ b/src/app/header/component.ts
@@ -4,6 +4,7 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'header-bar',
   templateUrl: './component.html',
+  styleUrls: ['./component.scss']
 })
 
 export class HeaderComponent {

--- a/src/app/school-list/component.html
+++ b/src/app/school-list/component.html
@@ -1,12 +1,8 @@
-BEGIN SCHOOLS ELEMENT
-<ul>
-  <li *ngFor="let school of schools">
-    <h5>School of {{school.name}}</h5>
-    <ul class="dept-list">
-      <li *ngFor="let department of school.departments">
-        <department [dept]="department"></department>
-      </li>
-    </ul>
-  </li>
-</ul>
-END SCHOOLS ELEMENT
+<div class="schools">
+  <div class="school" *ngFor="let school of schools">
+    <span class="school-name">{{school.name}}</span>
+    <div class="departments dept-list">
+      <department *ngFor="let department of school.departments" [dept]="department"></department>
+    </div>
+  </div>
+</div>

--- a/src/app/school-list/component.scss
+++ b/src/app/school-list/component.scss
@@ -1,0 +1,53 @@
+.schools {
+  display: block;
+  columns: 2 450px;
+  -moz-columns: 2 450px;
+  -webkit-columns: 2 450px;
+  column-gap: 20px;
+  -moz-column-gap: 20px;
+  -webkit-column-gap: 20px;
+  max-width: 950px;
+  margin: 0 auto;
+}
+
+.school {
+    display:inline-block;
+    width: 475px;
+    padding: 0px 1px;
+}
+.school-name {
+    display:block;
+    /*width:600px;*/
+    margin-right:10px;
+    font-size:21px;
+    font-style:italic;
+    padding: 0px 1px;
+    border-bottom: 1px black solid;
+}
+.departments {
+    display:block;
+    margin-bottom: 15px;
+    font-size:17px;
+}
+department {
+    display:block;
+    cursor:pointer;
+    padding:2px 5px;
+    /*width:5;*/
+}
+department:hover {
+/*    color: #fff;
+    background-color: #933;*/
+    color: white;
+    background-color: #c65353;
+}
+noscript {
+    color:#933;
+    font-weight:bold;
+    font-size:150%;
+}
+div#bottomtext {
+    display:block;
+    color:#afafaf;
+    margin-bottom:8px;
+}

--- a/src/app/school-list/component.ts
+++ b/src/app/school-list/component.ts
@@ -30,7 +30,7 @@ const SCHOOL_TEST_DATA: School[] = [
 @Component({
   selector: 'schools',
   templateUrl: './component.html',
-  // styleUrls: []
+  styleUrls: ['./component.scss']
 })
 export class SchoolListComponent implements OnInit {
   schools: School[];
@@ -39,12 +39,13 @@ export class SchoolListComponent implements OnInit {
 
   getSchools () {
     this.yacsService
-        .get('schools')
-        .then((data) => this.schools = data['schools'] as School[]);
+        .get('schools', { show_departments: true })
+        .then((data) => {
+          this.schools = data['schools'] as School[];
+        });
   }
 
   ngOnInit () : void {
     this.getSchools();
-    console.log(this.schools)
   }
 }

--- a/src/app/school-list/department/component.html
+++ b/src/app/school-list/department/component.html
@@ -1,3 +1,1 @@
-BEGIN DEPARTMENT
-<strong>{{dept.code}}</strong> {{dept.name}}
-END DEPARTMENT
+<span class="department-code">{{dept.code}}</span> {{dept.name}}

--- a/src/app/school-list/department/component.scss
+++ b/src/app/school-list/department/component.scss
@@ -1,0 +1,5 @@
+.department-code {
+  font-family:"Andale Mono","Courier New",monospace;
+  margin-right:0.4em;
+  font-size:120%;
+}

--- a/src/app/school-list/department/component.ts
+++ b/src/app/school-list/department/component.ts
@@ -9,6 +9,7 @@ export class Department {
 @Component({
     selector: 'department',
     templateUrl: './component.html',
+    styleUrls: ['./component.scss']
 })
 export class DepartmentComponent {
   // declare "dept" as a field of this component that comes from a []=

--- a/src/assets/styles/open_sans_300.css
+++ b/src/assets/styles/open_sans_300.css
@@ -1,0 +1,56 @@
+/* cyrillic-ext */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 300;
+  src: local('Open Sans Light'), local('OpenSans-Light'), url(https://fonts.gstatic.com/s/opensans/v13/DXI1ORHCpsQm3Vp6mXoaTQ7aC6SjiAOpAWOKfJDfVRY.woff2) format('woff2');
+  unicode-range: U+0460-052F, U+20B4, U+2DE0-2DFF, U+A640-A69F;
+}
+/* cyrillic */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 300;
+  src: local('Open Sans Light'), local('OpenSans-Light'), url(https://fonts.gstatic.com/s/opensans/v13/DXI1ORHCpsQm3Vp6mXoaTRdwxCXfZpKo5kWAx_74bHs.woff2) format('woff2');
+  unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* greek-ext */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 300;
+  src: local('Open Sans Light'), local('OpenSans-Light'), url(https://fonts.gstatic.com/s/opensans/v13/DXI1ORHCpsQm3Vp6mXoaTZ6vnaPZw6nYDxM4SVEMFKg.woff2) format('woff2');
+  unicode-range: U+1F00-1FFF;
+}
+/* greek */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 300;
+  src: local('Open Sans Light'), local('OpenSans-Light'), url(https://fonts.gstatic.com/s/opensans/v13/DXI1ORHCpsQm3Vp6mXoaTfy1_HTwRwgtl1cPga3Fy3Y.woff2) format('woff2');
+  unicode-range: U+0370-03FF;
+}
+/* vietnamese */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 300;
+  src: local('Open Sans Light'), local('OpenSans-Light'), url(https://fonts.gstatic.com/s/opensans/v13/DXI1ORHCpsQm3Vp6mXoaTfgrLsWo7Jk1KvZser0olKY.woff2) format('woff2');
+  unicode-range: U+0102-0103, U+1EA0-1EF1, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 300;
+  src: local('Open Sans Light'), local('OpenSans-Light'), url(https://fonts.gstatic.com/s/opensans/v13/DXI1ORHCpsQm3Vp6mXoaTYjoYw3YTyktCCer_ilOlhE.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 300;
+  src: local('Open Sans Light'), local('OpenSans-Light'), url(https://fonts.gstatic.com/s/opensans/v13/DXI1ORHCpsQm3Vp6mXoaTRampu5_7CjHW5spxoeN3Vs.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215, U+E0FF, U+EFFD, U+F000;
+}

--- a/src/assets/styles/open_sans_400.css
+++ b/src/assets/styles/open_sans_400.css
@@ -1,0 +1,56 @@
+/* cyrillic-ext */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Open Sans'), local('OpenSans'), url(https://fonts.gstatic.com/s/opensans/v13/K88pR3goAWT7BTt32Z01m4X0hVgzZQUfRDuZrPvH3D8.woff2) format('woff2');
+  unicode-range: U+0460-052F, U+20B4, U+2DE0-2DFF, U+A640-A69F;
+}
+/* cyrillic */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Open Sans'), local('OpenSans'), url(https://fonts.gstatic.com/s/opensans/v13/RjgO7rYTmqiVp7vzi-Q5UYX0hVgzZQUfRDuZrPvH3D8.woff2) format('woff2');
+  unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* greek-ext */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Open Sans'), local('OpenSans'), url(https://fonts.gstatic.com/s/opensans/v13/LWCjsQkB6EMdfHrEVqA1KYX0hVgzZQUfRDuZrPvH3D8.woff2) format('woff2');
+  unicode-range: U+1F00-1FFF;
+}
+/* greek */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Open Sans'), local('OpenSans'), url(https://fonts.gstatic.com/s/opensans/v13/xozscpT2726on7jbcb_pAoX0hVgzZQUfRDuZrPvH3D8.woff2) format('woff2');
+  unicode-range: U+0370-03FF;
+}
+/* vietnamese */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Open Sans'), local('OpenSans'), url(https://fonts.gstatic.com/s/opensans/v13/59ZRklaO5bWGqF5A9baEEYX0hVgzZQUfRDuZrPvH3D8.woff2) format('woff2');
+  unicode-range: U+0102-0103, U+1EA0-1EF1, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Open Sans'), local('OpenSans'), url(https://fonts.gstatic.com/s/opensans/v13/u-WUoqrET9fUeobQW7jkRYX0hVgzZQUfRDuZrPvH3D8.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Open Sans'), local('OpenSans'), url(https://fonts.gstatic.com/s/opensans/v13/cJZKeOuBrn4kERxqtaUH3ZBw1xU1rKptJj_0jans920.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215, U+E0FF, U+EFFD, U+F000;
+}

--- a/src/assets/styles/open_sans_600.css
+++ b/src/assets/styles/open_sans_600.css
@@ -1,0 +1,56 @@
+/* cyrillic-ext */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 600;
+  src: local('Open Sans Semibold'), local('OpenSans-Semibold'), url(https://fonts.gstatic.com/s/opensans/v13/MTP_ySUJH_bn48VBG8sNSg7aC6SjiAOpAWOKfJDfVRY.woff2) format('woff2');
+  unicode-range: U+0460-052F, U+20B4, U+2DE0-2DFF, U+A640-A69F;
+}
+/* cyrillic */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 600;
+  src: local('Open Sans Semibold'), local('OpenSans-Semibold'), url(https://fonts.gstatic.com/s/opensans/v13/MTP_ySUJH_bn48VBG8sNShdwxCXfZpKo5kWAx_74bHs.woff2) format('woff2');
+  unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* greek-ext */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 600;
+  src: local('Open Sans Semibold'), local('OpenSans-Semibold'), url(https://fonts.gstatic.com/s/opensans/v13/MTP_ySUJH_bn48VBG8sNSp6vnaPZw6nYDxM4SVEMFKg.woff2) format('woff2');
+  unicode-range: U+1F00-1FFF;
+}
+/* greek */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 600;
+  src: local('Open Sans Semibold'), local('OpenSans-Semibold'), url(https://fonts.gstatic.com/s/opensans/v13/MTP_ySUJH_bn48VBG8sNSvy1_HTwRwgtl1cPga3Fy3Y.woff2) format('woff2');
+  unicode-range: U+0370-03FF;
+}
+/* vietnamese */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 600;
+  src: local('Open Sans Semibold'), local('OpenSans-Semibold'), url(https://fonts.gstatic.com/s/opensans/v13/MTP_ySUJH_bn48VBG8sNSvgrLsWo7Jk1KvZser0olKY.woff2) format('woff2');
+  unicode-range: U+0102-0103, U+1EA0-1EF1, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 600;
+  src: local('Open Sans Semibold'), local('OpenSans-Semibold'), url(https://fonts.gstatic.com/s/opensans/v13/MTP_ySUJH_bn48VBG8sNSojoYw3YTyktCCer_ilOlhE.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 600;
+  src: local('Open Sans Semibold'), local('OpenSans-Semibold'), url(https://fonts.gstatic.com/s/opensans/v13/MTP_ySUJH_bn48VBG8sNShampu5_7CjHW5spxoeN3Vs.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215, U+E0FF, U+EFFD, U+F000;
+}

--- a/src/assets/styles/open_sans_700.css
+++ b/src/assets/styles/open_sans_700.css
@@ -1,0 +1,56 @@
+/* cyrillic-ext */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v13/k3k702ZOKiLJc3WVjuplzA7aC6SjiAOpAWOKfJDfVRY.woff2) format('woff2');
+  unicode-range: U+0460-052F, U+20B4, U+2DE0-2DFF, U+A640-A69F;
+}
+/* cyrillic */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v13/k3k702ZOKiLJc3WVjuplzBdwxCXfZpKo5kWAx_74bHs.woff2) format('woff2');
+  unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* greek-ext */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v13/k3k702ZOKiLJc3WVjuplzJ6vnaPZw6nYDxM4SVEMFKg.woff2) format('woff2');
+  unicode-range: U+1F00-1FFF;
+}
+/* greek */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v13/k3k702ZOKiLJc3WVjuplzPy1_HTwRwgtl1cPga3Fy3Y.woff2) format('woff2');
+  unicode-range: U+0370-03FF;
+}
+/* vietnamese */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v13/k3k702ZOKiLJc3WVjuplzPgrLsWo7Jk1KvZser0olKY.woff2) format('woff2');
+  unicode-range: U+0102-0103, U+1EA0-1EF1, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v13/k3k702ZOKiLJc3WVjuplzIjoYw3YTyktCCer_ilOlhE.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(https://fonts.gstatic.com/s/opensans/v13/k3k702ZOKiLJc3WVjuplzBampu5_7CjHW5spxoeN3Vs.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215, U+E0FF, U+EFFD, U+F000;
+}

--- a/src/assets/styles/open_sans_800.css
+++ b/src/assets/styles/open_sans_800.css
@@ -1,0 +1,56 @@
+/* cyrillic-ext */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 800;
+  src: local('Open Sans Extrabold'), local('OpenSans-Extrabold'), url(https://fonts.gstatic.com/s/opensans/v13/EInbV5DfGHOiMmvb1Xr-hg7aC6SjiAOpAWOKfJDfVRY.woff2) format('woff2');
+  unicode-range: U+0460-052F, U+20B4, U+2DE0-2DFF, U+A640-A69F;
+}
+/* cyrillic */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 800;
+  src: local('Open Sans Extrabold'), local('OpenSans-Extrabold'), url(https://fonts.gstatic.com/s/opensans/v13/EInbV5DfGHOiMmvb1Xr-hhdwxCXfZpKo5kWAx_74bHs.woff2) format('woff2');
+  unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* greek-ext */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 800;
+  src: local('Open Sans Extrabold'), local('OpenSans-Extrabold'), url(https://fonts.gstatic.com/s/opensans/v13/EInbV5DfGHOiMmvb1Xr-hp6vnaPZw6nYDxM4SVEMFKg.woff2) format('woff2');
+  unicode-range: U+1F00-1FFF;
+}
+/* greek */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 800;
+  src: local('Open Sans Extrabold'), local('OpenSans-Extrabold'), url(https://fonts.gstatic.com/s/opensans/v13/EInbV5DfGHOiMmvb1Xr-hvy1_HTwRwgtl1cPga3Fy3Y.woff2) format('woff2');
+  unicode-range: U+0370-03FF;
+}
+/* vietnamese */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 800;
+  src: local('Open Sans Extrabold'), local('OpenSans-Extrabold'), url(https://fonts.gstatic.com/s/opensans/v13/EInbV5DfGHOiMmvb1Xr-hvgrLsWo7Jk1KvZser0olKY.woff2) format('woff2');
+  unicode-range: U+0102-0103, U+1EA0-1EF1, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 800;
+  src: local('Open Sans Extrabold'), local('OpenSans-Extrabold'), url(https://fonts.gstatic.com/s/opensans/v13/EInbV5DfGHOiMmvb1Xr-hojoYw3YTyktCCer_ilOlhE.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 800;
+  src: local('Open Sans Extrabold'), local('OpenSans-Extrabold'), url(https://fonts.gstatic.com/s/opensans/v13/EInbV5DfGHOiMmvb1Xr-hhampu5_7CjHW5spxoeN3Vs.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215, U+E0FF, U+EFFD, U+F000;
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,14 +1,41 @@
 /* You can add global styles to this file, and also import other style files */
+@import "./_vars.scss";
+
 
 body {
-  /*background-color:#efefef;*/
-  color: #000;
-  font-family: "Open Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
-  font-weight: 300;
-  margin: 0;
+    color: #000;
+    font-family: $font;
+    margin: 0;
+    font-weight: 300;
 }
 
-a {
-  text-decoration: none;
-  color: inherit;
+#content {
+    padding: 60px 15px 0px 15px;    
+}
+
+
+#loading {
+    position:absolute;
+    top: 50%;
+    left: 50%;
+    /* browsers handle fractional pixel values differently, but the worst that
+       can happen is that it's 1/2 pixel off center. So it's best to use the
+       real values (half of the image width and height) here. */
+    margin-top: -4.5px;
+    margin-left: -62.5px;       
+}
+
+footer {
+    margin: 0px auto;
+    max-width: 950px;
+}
+
+.noselect {
+  -webkit-touch-callout: none; /* iOS Safari */
+    -webkit-user-select: none; /* Safari */
+     -khtml-user-select: none; /* Konqueror HTML */
+       -moz-user-select: none; /* Firefox */
+        -ms-user-select: none; /* Internet Explorer/Edge */
+            user-select: none; /* Non-prefixed version, currently
+                                  supported by Chrome and Opera */
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,1 +1,14 @@
 /* You can add global styles to this file, and also import other style files */
+
+body {
+  /*background-color:#efefef;*/
+  color: #000;
+  font-family: "Open Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
+  font-weight: 300;
+  margin: 0;
+}
+
+a {
+  text-decoration: none;
+  color: inherit;
+}


### PR DESCRIPTION
This pull request addresses issue #4.

I have successfully implemented the `schools` component as well as the `departments` component such that when you navigate to /schools, everything matches how the live yacs website looks.

This involved rewriting certain existing .html, .ts, and .css/scss files within the /school-list directory, the /header director, the /footer directory, and general dependency additions to the root .angular-cli.json file. Changes to the root styles.scss were made as well, because there are global styles that are shared across multiple components.