### PR TITLE
Finish section/courses layout view

### DIFF
--- a/src/app/app-router/module.ts
+++ b/src/app/app-router/module.ts
@@ -1,13 +1,13 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { SchoolListComponent } from '../school-list/component';
-import { CourseListComponent } from '../course-list/component';
+import { CourseViewComponent } from '../course-view/component';
 import { ScheduleViewComponent } from '../schedule-view/component';
 
 const routes: Routes = [
   { path: '', redirectTo: '/schools', pathMatch: 'full' },
   { path: 'schools', component: SchoolListComponent },
-  { path: 'courses', component: CourseListComponent },
+  { path: 'courses', component: CourseViewComponent },
   { path: 'schedules', component: ScheduleViewComponent },
 ];
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -9,7 +9,7 @@ import { HeaderComponent } from './header/component';
 import { FooterComponent } from './footer/component';
 
 import { SchoolListModule } from './school-list/module';
-import { CourseListModule } from './course-list/module';
+import { CourseViewModule } from './course-view/module';
 import { ScheduleViewModule } from './schedule-view/module';
 
 import { ConstantsService } from './services/constants';
@@ -21,7 +21,7 @@ import { ConstantsService } from './services/constants';
     HttpModule,
     AppRouterModule,
     SchoolListModule,
-    CourseListModule,
+    CourseViewModule,
     ScheduleViewModule
   ],
   declarations: [

--- a/src/app/course-list/component.html
+++ b/src/app/course-list/component.html
@@ -1,5 +1,2 @@
-THIS IS THE COURSE LIST
-<div id="courseList"> <!-- This element may not be needed -->
-  <course *ngFor="let theCourse of courses" [course]="theCourse">
-  </course>
-</div>
+<course *ngFor="let theCourse of courses" [course]="theCourse">
+</course>

--- a/src/app/course-list/component.scss
+++ b/src/app/course-list/component.scss
@@ -1,0 +1,12 @@
+course {
+    display: block;
+    margin: 0px 20px;
+    padding:15px;
+    border-bottom: 1px #bbb solid;
+    cursor: pointer;
+    max-width: 950px;
+    margin: 0 auto;
+}
+course:last-child {
+    border: none;
+}

--- a/src/app/course-list/component.ts
+++ b/src/app/course-list/component.ts
@@ -1,5 +1,5 @@
-import { Component, OnInit, Input } from '@angular/core';
-import { Course } from '../course-list/course/component';
+import { Component, Input } from '@angular/core';
+import { Course } from '../course-list/course/course';
 
 
 @Component({
@@ -7,13 +7,7 @@ import { Course } from '../course-list/course/component';
     templateUrl: './component.html',
     styleUrls: ['./component.scss']
 })
-export class CourseListComponent implements OnInit {
+export class CourseListComponent {
 
   @Input() courses : Course[];
-
-  constructor () {}
-
-  ngOnInit () : void {
-    
-  }
 }

--- a/src/app/course-list/component.ts
+++ b/src/app/course-list/component.ts
@@ -1,57 +1,19 @@
-import { Component } from '@angular/core';
-import { Course } from './course/component';
-
-const COURSELIST_TEST_DATA: Course[] = [
-  {
-    id: 1,
-    name: 'Data Structures',
-    num: '1200',
-    departmentCode: 'CSCI',
-    minCredits: 4,
-    maxCredits: 4,
-    description: 'Hash maps. Hash maps everywhere.',
-    sections: [
-      {
-        id: 1,
-        courseId: 1,
-        name: '01',
-        crn: 1337,
-        instructors: ['Cutler', 'Thompson'],
-        seats: 10,
-        seatsTaken: 3,
-        conflicts: [34, 54, 63],
-        periods: [
-          { form: 'LEC', startTime: 3480, endTime: 3590 },
-          { form: 'TES', startTime: 3960, endTime: 4070 },
-          { form: 'LAB', startTime: 4920, endTime: 5030 },
-          { form: 'LEC', startTime: 6360, endTime: 6470 }
-        ]
-      },
-      {
-        id: 2,
-        courseId: 1,
-        name: '02',
-        crn: 1338,
-        instructors: ['Cutler', 'Thompson'],
-        seats: 10,
-        seatsTaken: 6,
-        conflicts: [34, 54, 63],
-        periods: [
-          { form: 'LEC', startTime: 3480, endTime: 3590 },
-          { form: 'TES', startTime: 3960, endTime: 4070 },
-          { form: 'LAB', startTime: 5040, endTime: 5150 },
-          { form: 'LEC', startTime: 6360, endTime: 6470 }
-        ]
-      }
-    ]
-  }
-];
+import { Component, OnInit, Input } from '@angular/core';
+import { Course } from '../course-list/course/component';
 
 
 @Component({
     selector: 'course-list',
-    templateUrl: './component.html'
+    templateUrl: './component.html',
+    styleUrls: ['./component.scss']
 })
-export class CourseListComponent {
-  courses = COURSELIST_TEST_DATA;
+export class CourseListComponent implements OnInit {
+
+  @Input() courses : Course[];
+
+  constructor () {}
+
+  ngOnInit () : void {
+    
+  }
 }

--- a/src/app/course-list/course/component.html
+++ b/src/app/course-list/course/component.html
@@ -1,12 +1,12 @@
-THIS IS A COURSE
 <div class="course-info">
-  <h4 class="course-name">{{course.name}}</h4>
-  <span class="dept-code">{{course.departmentCode}}</span>
-  <span class="course-number">{{course.num}}</span>
+  <span class="course-name">{{course.name}}</span>
+  <span class="dept-code">{{course.sections[0].department_code}}</span> <!-- api issues, so have to grab dept code by going into sections for now -->
+  <span class="course-number">{{course.number}}</span>
   <span class="credit-range">{{creditRange}}</span>
   <div class="course-description">
     {{ course.description }}
   </div>
-  <div class="section-list">
-    <section *ngFor="let theSection of course.sections" [section]="theSection"></section>
+</div>
+<div class="section-list">
+  <section *ngFor="let theSection of course.sections" [section]="theSection"></section>
 </div>

--- a/src/app/course-list/course/component.scss
+++ b/src/app/course-list/course/component.scss
@@ -1,0 +1,46 @@
+.course-name {
+    font-size: 130%;
+    font-weight: 400;
+}
+.dept-code {
+    margin-left:1em;
+}
+.credit-range {
+    margin-left:0.7em;
+}
+.course-description {
+    display:block;
+    font-size:87%;
+    text-align: justify;
+}
+:host:not(.selected)>.course-info:hover ~ .section-list section:not(.selected):not(.closed) {
+    background-color: #d57f7f;
+}
+:host.selected>.course-info:hover ~ .section-list section.selected {
+    color: #efefef;
+    background-color: #d57f7f;
+}
+section {
+    display:block;
+    margin:0px 0px 0px 5px;
+    padding:4px 4px 4px 8px;
+    overflow:auto;
+    font-size: 90%;
+}
+section:not(.selected):hover {
+    background-color: #d57f7f;
+}
+section.selected:hover {
+    color: #efefef;
+    background-color: #d57f7f;
+}
+section.selected {
+    color: #efefef;
+    background-color: #c65353;
+}
+section.closed, section.closed:hover {
+    color: #888;
+}
+section.conflicts, section.conflicts:hover {
+    color: #aaa;
+}

--- a/src/app/course-list/course/component.ts
+++ b/src/app/course-list/course/component.ts
@@ -1,17 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { Section } from '../section/component';
-
-export class Course {
-  id: number;
-  name: string;
-  num: string;
-  department_code: string;
-  department_id: number;
-  min_credits:number;
-  max_credits:number;
-  description: string;
-  sections: Section[];
-}
+import { Course } from './course';
 
 @Component({
   selector: 'course',

--- a/src/app/course-list/course/component.ts
+++ b/src/app/course-list/course/component.ts
@@ -5,9 +5,10 @@ export class Course {
   id: number;
   name: string;
   num: string;
-  departmentCode: string;
-  minCredits:number;
-  maxCredits:number;
+  department_code: string;
+  department_id: number;
+  min_credits:number;
+  max_credits:number;
   description: string;
   sections: Section[];
 }
@@ -15,6 +16,7 @@ export class Course {
 @Component({
   selector: 'course',
   templateUrl: './component.html',
+  styleUrls: ['./component.scss']
 })
 export class CourseComponent {
   @Input() course: Course;
@@ -22,8 +24,8 @@ export class CourseComponent {
   /* A getter function for the range of credits based on the min and max.
    * When {{creditRange}} is used in the template, this function will be called. */
   public get creditRange() {
-    let minCredits = this.course.minCredits;
-    let maxCredits = this.course.minCredits;
+    let minCredits = this.course.min_credits;
+    let maxCredits = this.course.max_credits;
     let outstr = '';
     let plural = true;
     if(minCredits !== maxCredits) {

--- a/src/app/course-list/course/course.ts
+++ b/src/app/course-list/course/course.ts
@@ -1,0 +1,13 @@
+import { Section } from '../section/section';
+
+export class Course {
+  id: number;
+  name: string;
+  num: string;
+  department_code: string;
+  department_id: number;
+  min_credits:number;
+  max_credits:number;
+  description: string;
+  sections: Section[];
+}

--- a/src/app/course-list/module.ts
+++ b/src/app/course-list/module.ts
@@ -13,6 +13,9 @@ import { SectionComponent } from './section/component';
   ],
   imports: [
     CommonModule
+  ],
+  exports: [
+    CourseListComponent
   ]
 })
-export class CourseListModule {}
+export class CourseListModule { }

--- a/src/app/course-list/section/component.html
+++ b/src/app/course-list/section/component.html
@@ -1,12 +1,13 @@
-THIS IS A SECTION
 <span class="section-name">{{section.name}}</span>
 <span class="section-crn">{{section.crn}}</span>
 <span class="section-instructors">{{ section.instructors.join(', ') }}</span>
-<span class="section-seats">{{ section.seatsAvailable }} / {{ section.seats }} seats</span>
+<span class="section-seats-available">
+  {{ section.seats-section.seats_taken }}<span class="section-seats">/{{ section.seats }} seats</span>
+</span>
 <!-- conflicts here... -->
 <div class="section-periods">
-  <div class="period" *ngFor="let period of section.periods">
+  <span class="period" *ngFor="let period of section.periods">
     <span class="period-day">{{ getDay(period) }}</span>
     <span class="period-time">{{ getHours(period) }}</span>
-  </div>
+  </span>
 </div>

--- a/src/app/course-list/section/component.scss
+++ b/src/app/course-list/section/component.scss
@@ -1,0 +1,47 @@
+.conflicts>section-information {
+    text-decoration: line-through;
+}
+.section-name {
+    font-weight: 400;
+}
+.section-seats {
+    font-size: 80%;
+}
+.section-periods {
+    font-size:80%;
+    display:inline-block;
+    margin-left:0em;
+    float:right;
+    padding:0.15em 0;
+}
+.section-periods.noperiods {
+    font-weight: bold;
+}
+.period {
+    margin-left:1em;
+}
+.period-day {
+    font-weight: 400;
+}
+div.conflict-note {
+    margin-left:0.4em;
+    display:inline;
+    color:#000;
+}
+:not(.conflicts)>div.conflict-note {
+    display:none;
+}
+span.conflict-img-center {
+    display:inline-block;
+    height:100%;
+    vertical-align:middle;
+}
+img.conflict-img {
+    display:inline-block;
+    vertical-align:middle;
+    width: 0.9em;
+}
+span.conflict-text {
+    font-size:75%;
+    color: #cf2c2c;
+}

--- a/src/app/course-list/section/component.ts
+++ b/src/app/course-list/section/component.ts
@@ -1,22 +1,27 @@
 import { Component, Input } from '@angular/core';
 
 export class Period {
-  form: string;
-  // start and end are in MINUTES SINCE START OF THE WEEK
-  startTime: number;
-  endTime: number;
+  type: string;
+  day: number;
+  // start and end are in MINUTES SINCE START OF THE WEEK // no?
+  start: number;
+  end: number;
 }
 
 export class Section {
   id: number;
-  courseId: number;
+  course_id: number;
   name: string;
   crn: number;
   instructors: string[];
   seats: number;
-  seatsTaken: number;
+  seats_taken: number;
   conflicts: number[];
   periods: Period[];
+  num_periods: number;
+  course_name: string;
+  course_number: number;
+  department_code: string;
 }
 
 const SHORT_DAYS: string[] = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sam'];
@@ -25,14 +30,13 @@ const MINUTES_PER_DAY: number = 1440;
 @Component({
   selector: 'section',
   templateUrl: './component.html',
+  styleUrls: ['./component.scss']
 })
 export class SectionComponent {
   @Input() section: Section;
 
   public getDay(period: Period) : string {
-    console.log(period);
-    // Assume that the period doesn't include midnight, so only worry about the start time.
-    return SHORT_DAYS[Math.floor(period.startTime / MINUTES_PER_DAY)];
+    return SHORT_DAYS[period.day];
   }
 
   /**
@@ -43,28 +47,27 @@ export class SectionComponent {
    * etc
    * This should possibly be a service.
    */
-  private timeToString(weekMinutes: number) : string {
-    let dayMinutes = weekMinutes % MINUTES_PER_DAY;
-    let hour = Math.floor(dayMinutes / 60);
-    let minutes = dayMinutes % 60;
+  private timeToString(time: number) : string {
+    let hour = Math.floor(time / 100);
+    let minute = Math.floor(time % 100);
+
     let ampm = 'a';
-    let minuteShow = '';
     if (hour >= 12) {
       ampm = 'p';
       if (hour > 12) {
         hour -= 12;
       }
     }
-    if(minutes === 0) {
-      minuteShow = '';
+
+    let minuteShow = '';
+    if (minute != 0) {
+      minuteShow = ':' + (minute < 10 ? '0' : '') + minute;
     }
-    else {
-      minuteShow = ':' + (minutes < 10 ? '0' : '') + minutes;
-    }
+
     return hour + minuteShow + ampm;
   }
 
   public getHours(period: Period) : string {
-    return this.timeToString(period.startTime) + '-' + this.timeToString(period.endTime);
+    return this.timeToString(period.start) + '-' + this.timeToString(period.end);
   }
 }

--- a/src/app/course-list/section/component.ts
+++ b/src/app/course-list/section/component.ts
@@ -1,31 +1,9 @@
 import { Component, Input } from '@angular/core';
 
-export class Period {
-  type: string;
-  day: number;
-  // start and end are in MINUTES SINCE START OF THE WEEK // no?
-  start: number;
-  end: number;
-}
-
-export class Section {
-  id: number;
-  course_id: number;
-  name: string;
-  crn: number;
-  instructors: string[];
-  seats: number;
-  seats_taken: number;
-  conflicts: number[];
-  periods: Period[];
-  num_periods: number;
-  course_name: string;
-  course_number: number;
-  department_code: string;
-}
+import { Section } from './section';
+import { Period } from './period';
 
 const SHORT_DAYS: string[] = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sam'];
-const MINUTES_PER_DAY: number = 1440;
 
 @Component({
   selector: 'section',

--- a/src/app/course-list/section/period.ts
+++ b/src/app/course-list/section/period.ts
@@ -1,0 +1,7 @@
+export class Period {
+  type: string;
+  day: number;
+  // start and end are in MINUTES SINCE START OF THE WEEK // no?
+  start: number;
+  end: number;
+}

--- a/src/app/course-list/section/section.ts
+++ b/src/app/course-list/section/section.ts
@@ -1,0 +1,17 @@
+import { Period } from './period';
+
+export class Section {
+  id: number;
+  course_id: number;
+  name: string;
+  crn: number;
+  instructors: string[];
+  seats: number;
+  seats_taken: number;
+  conflicts: number[];
+  periods: Period[];
+  num_periods: number;
+  course_name: string;
+  course_number: number;
+  department_code: string;
+}

--- a/src/app/course-view/component.html
+++ b/src/app/course-view/component.html
@@ -1,0 +1,1 @@
+<course-list [courses]="courses"></course-list>

--- a/src/app/course-view/component.ts
+++ b/src/app/course-view/component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { Router, ActivatedRoute, Params } from '@angular/router';
-import { Course } from '../course-list/course/component';
+import { Course } from '../course-list/course/course';
 import { YacsService } from '../services/yacs.service';
 
 
@@ -18,9 +18,12 @@ export class CourseViewComponent implements OnInit {
     private activatedRoute: ActivatedRoute) { }
 
   getCourses (params: Params) {
-    let newParams : Object = {};
-    // add show_sections to params
-    Object.assign(newParams, params, { show_sections: true, show_periods: true }); // cannot directly modify params for some reason
+    let newParams : Object = {
+      show_sections: true,
+      show_periods: true
+    };
+    // add show_sections and show_periods to params
+    Object.assign(newParams, params); // cannot directly modify params
     this.yacsService
         .get('courses', newParams)
         .then((data) => {

--- a/src/app/course-view/component.ts
+++ b/src/app/course-view/component.ts
@@ -1,0 +1,36 @@
+import { Component, OnInit } from '@angular/core';
+import { Router, ActivatedRoute, Params } from '@angular/router';
+import { Course } from '../course-list/course/component';
+import { YacsService } from '../services/yacs.service';
+
+
+@Component({
+  selector: 'course-view',
+  templateUrl: './component.html',
+  styleUrls: ['./component.scss']
+})
+export class CourseViewComponent implements OnInit {
+
+  courses : Course[] = [];
+
+  constructor (
+    private yacsService : YacsService,
+    private activatedRoute: ActivatedRoute) { }
+
+  getCourses (params: Params) {
+    let newParams : Object = {};
+    // add show_sections to params
+    Object.assign(newParams, params, { show_sections: true, show_periods: true }); // cannot directly modify params for some reason
+    this.yacsService
+        .get('courses', newParams)
+        .then((data) => {
+          this.courses = data['courses'] as Course[];
+        });
+  }
+
+  ngOnInit () : void {
+    this.activatedRoute.queryParams.subscribe((params: Params) => {
+      this.getCourses(params);
+    });
+  }
+}

--- a/src/app/course-view/module.ts
+++ b/src/app/course-view/module.ts
@@ -1,0 +1,18 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { CourseViewComponent } from './component';
+
+import { CourseListModule } from '../course-list/module';
+
+
+@NgModule({
+  imports: [
+    CommonModule,
+    CourseListModule
+  ],
+  declarations: [
+    CourseViewComponent
+  ]
+})
+export class CourseViewModule { }

--- a/src/app/header/component.html
+++ b/src/app/header/component.html
@@ -6,7 +6,7 @@
       <td>
         <span id="searchcontainer">
           <img id="searchglyph" src="assets/images/search.svg"/>
-          <input id="searchbar" placeholder="Search Fall 2017"/>
+          <input #term id="searchbar" placeholder="Search Fall 2017" (keyup.enter)="search(term.value)"/>
         </span>
       </td>
       <td class="sidelink" id="schedule-btn">

--- a/src/app/header/component.ts
+++ b/src/app/header/component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-// Every component must be declared in one - and only one - Angular module.
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'header-bar',
@@ -8,6 +8,13 @@ import { Component } from '@angular/core';
 })
 
 export class HeaderComponent {
-  searchText = '';
 
+  constructor(private router: Router) { }
+
+  search(term: string) {
+    this.router.navigate(['/courses'],
+      { queryParams: {
+        search: term
+      }});
+  }
 }

--- a/src/app/school-list/component.html
+++ b/src/app/school-list/component.html
@@ -2,7 +2,7 @@
   <div class="school" *ngFor="let school of schools">
     <span class="school-name">{{school.name}}</span>
     <div class="departments dept-list">
-      <department *ngFor="let department of school.departments" [dept]="department"></department>
+      <department *ngFor="let department of school.departments" [dept]="department" [routerLink]="['/courses']" [queryParams]="{ department_id: department.id }"></department>
     </div>
   </div>
 </div>

--- a/src/app/school-list/component.ts
+++ b/src/app/school-list/component.ts
@@ -8,25 +8,6 @@ export class School {
     departments: Department[];
 }
 
-const SCHOOL_TEST_DATA: School[] = [
-    {
-        id:1,
-        name:'Science',
-        departments: [
-            {
-                id: 1,
-                code: 'CSCI',
-                name: 'Computer Science'
-            },
-            {
-                id: 2,
-                code: 'MATH',
-                name: 'Mathematics'
-            }
-        ]
-    }
-];
-
 @Component({
   selector: 'schools',
   templateUrl: './component.html',

--- a/src/app/school-list/component.ts
+++ b/src/app/school-list/component.ts
@@ -1,12 +1,7 @@
 import { Component, OnInit } from '@angular/core';
-import { Department } from './department/component';
 import { YacsService } from '../services/yacs.service';
 
-export class School {
-    id: number;
-    name: string;
-    departments: Department[];
-}
+import { School } from './school';
 
 @Component({
   selector: 'schools',

--- a/src/app/school-list/department/component.ts
+++ b/src/app/school-list/department/component.ts
@@ -1,10 +1,5 @@
 import { Component, Input } from '@angular/core';
-
-export class Department {
-    id: number;
-    code: string;
-    name: string;
-}
+import { Department } from './department'
 
 @Component({
     selector: 'department',

--- a/src/app/school-list/department/department.ts
+++ b/src/app/school-list/department/department.ts
@@ -1,0 +1,5 @@
+export class Department {
+  id: number;
+  code: string;
+  name: string;
+}

--- a/src/app/school-list/module.ts
+++ b/src/app/school-list/module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 // this is added so that an ngFor in the schools html will work.
 import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
 
 import { SchoolListComponent } from './component';
 import { DepartmentComponent } from './department/component';
@@ -12,7 +13,8 @@ import { YacsService } from '../services/yacs.service';
         DepartmentComponent
     ],
     imports: [
-      CommonModule
+      CommonModule,
+      RouterModule
     ],
     providers: [YacsService],
 })

--- a/src/app/school-list/school.ts
+++ b/src/app/school-list/school.ts
@@ -1,0 +1,7 @@
+import { Department } from './department/department';
+
+export class School {
+  id: number;
+  name: string;
+  departments: Department[];
+}

--- a/src/app/services/yacs.service.ts
+++ b/src/app/services/yacs.service.ts
@@ -12,7 +12,7 @@ export class YacsService {
   constructor (private http: Http) {}
 
   get (path: string, params: Object = {}): Promise<Object[]> {
-    return this.http.get(`${this.baseUrl}/${path}?${this.objectToQueryString(params)}`)
+    return this.http.get(`${this.baseUrl}/${path}.json?${this.objectToQueryString(params)}`)
                     .toPromise()
                     .then(this.extractData)
                     .catch(this.handleError);


### PR DESCRIPTION
This pull request addresses issue #6.

I have successfully implemented the course-list component such that when you navigate to /courses?any_query=any_query_args, everything matches how the live yacs website looks.

This involved rewriting certain existing .html, .ts, and .css/scss files within the /course-list directory. The biggest change is the introduction of a new module `CourseViewModule` and its component `CourseViewComponent` through slight refactoring of how modules and router paths are called.

The purpose of the new module is to create a self-containing group such that it is consistent with how the current directory structure is laid out. This change would also make the implementation of lazy-loading easier, should we decide to implement it. The other purpose of separating `course-view` and `course-list` is so that the `schedule-view` could reuse the `course-list` component without rewriting everything.

The `CourseViewComponent` directly uses `CourseListComponent`, which displays any list of courses fed into it.