### PR TITLE
Reconfigure build system for new yacs-orchestra config

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -6,7 +6,7 @@
   "apps": [
     {
       "root": "src",
-      "outDir": "dist",
+      "outDir": "dist-web/public",
       "assets": [
         "assets",
         "favicon.ico"

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+dist-web

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # See http://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
-/dist
+/dist/core
 /tmp
 /out-tsc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: required
+
+language: node_js
+
+node_js:
+  - '7'
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,10 @@ WORKDIR $APP_DIR
 
 RUN npm install -g @angular/cli --silent --depth 1
 COPY package.json $APP_DIR
-COPY .angular-cli.json karma.conf.js protractor.conf.js tsconfig.json tslint.json $APP_DIR
 RUN npm install --silent --depth 0
+COPY .angular-cli.json karma.conf.js protractor.conf.js tsconfig.json tslint.json $APP_DIR
 
 COPY ./src $APP_DIR
-RUN npm build --prod
+RUN npm build
+
+VOLUME /usr/src/app/dist-web

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve --host 0.0.0.0 --disable-host-check",
-    "build": "ng build",
+    "watch": "ng build --watch",
+    "build": "ng build --prod",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"

--- a/src/app/services/selection.service.ts
+++ b/src/app/services/selection.service.ts
@@ -81,7 +81,7 @@ export class SelectionService {
   }
 
   public getSelections() {
-    return JSON.parse(this.getItem('selections'));
+    return JSON.parse(this.getItem('selections')) || {};
   }
   
   public getSelectedSectionIds () {

--- a/src/app/services/yacs.service.ts
+++ b/src/app/services/yacs.service.ts
@@ -7,7 +7,7 @@ import 'rxjs/add/operator/toPromise';
 
 @Injectable()
 export class YacsService {
-  protected baseUrl = 'http://yacs.cs.rpi.edu/api/v5';
+  protected baseUrl = '/api/v5';
 
   constructor (private http: Http) {}
 

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>YACS</title>
-  <base href="/">
+  <base href="./">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "outDir": "./dist/out-tsc",
+    "outDir": "./dist-web/public/out-tsc",
     "baseUrl": "src",
     "sourceMap": true,
     "declaration": false,


### PR DESCRIPTION
This PR reconfigures the build to work behind nginx in development mode.

- Reconfigure build system to write to disk so nginx can be used transparently in dev mode
  - The page must be refreshed to see changes in dev mode (for now)
- Add .dockerignore so node_modules and local builds aren't copied to the Docker image
- Optimize order of Dockerfile commands
- Use local server for YACS api
- Fix a bug that breaks schedule page when no selections are stored