### PR TITLE
Typeahead drop down does not display on only white space

### DIFF
--- a/src/app/header/component.ts
+++ b/src/app/header/component.ts
@@ -43,7 +43,7 @@ export class HeaderComponent {
         this.yacsService
           .get('courses', { search: term })
           .then(data => {
-            if (term.length > 2) {                      //only show results after 3 characters
+            if (term.length > 2 && /\S/.test(term)) {                      //only show results after 3 characters
               let courses = (data['courses'] as Course[])
                 .map(c => c.name);
               return courses


### PR DESCRIPTION
The search bar drop down originally displayed after only 3 characters were typed which included only 3 spaces. This PR fixes that issue so that the drop down only displays with 3 characters that are not only white space. 