### PR TITLE
Add responsive header with login/logout 

### DIFF
--- a/src/_vars.scss
+++ b/src/_vars.scss
@@ -1,3 +1,4 @@
 $font: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
 $yacs_bgs: #C65353;
 $yacs_link: #993333;
+$header_height: 50px;

--- a/src/_vars.scss
+++ b/src/_vars.scss
@@ -1,3 +1,3 @@
 $font: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
 $yacs_bgs: #C65353;
-
+$yacs_link: #993333;

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,12 +1,12 @@
-header-bar {
-  width:100%;
-  height:50px;
-  position:fixed;
-  z-index: 1;
-  color: white;
-  background-color: #c65353;
-  white-space: nowrap;
-}
+// header-bar {
+//   width:100%;
+//   height:50px;
+//   position:fixed;
+//   z-index: 1;
+//   color: white;
+//   background-color: #c65353;
+//   white-space: nowrap;
+// }
 
 div#content {
   padding: 60px 15px 0px 15px;

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -8,6 +8,7 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 
 import { AppComponent } from './app.component';
 import { HeaderComponent } from './header/component';
+import { NavUserComponent } from './header/nav-user/component';
 import { NoticeBarComponent } from './notice-bar/component';
 import { FooterComponent } from './footer/component';
 
@@ -19,6 +20,7 @@ import { ConstantsService } from './services/constants';
 import { SelectionService } from './services/selection.service';
 import { ConflictsService } from './services/conflicts.service';
 import { NoticeService } from './services/notice.service';
+import { UserService } from './services/user.service';
 
 import { AboutComponent } from './about/component';
 
@@ -39,13 +41,15 @@ import { AboutComponent } from './about/component';
     HeaderComponent,
     NoticeBarComponent,
     FooterComponent,
-    AboutComponent
+    AboutComponent,
+    NavUserComponent
   ],
   providers: [
     ConstantsService,
     SelectionService,
     ConflictsService,
-    NoticeService
+    NoticeService,
+    UserService
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/header/component.html
+++ b/src/app/header/component.html
@@ -1,15 +1,15 @@
-<nav class="navbar navbar-custom fixed-top navbar-expand-md flex-wrap2 flex-md-nowrap p-0">
+<nav class="navbar navbar-custom fixed-top navbar-expand-sm flex-wrap2 flex-md-nowrap p-0">
   <a class="navbar-brand col-auto mr-0 yacs-link" [routerLink]="['/']" (click)="navbarCollapsed = true">
     <span class="theme-text theme-text-heavy">Yacs</span>
   </a>
 
-  <button class="navbar-toggler d-md-none mt-1 mr-0" type="button" (click)="navbarCollapsed = !navbarCollapsed" 
+  <button class="navbar-toggler d-sm-none mt-1 mr-0" type="button" (click)="navbarCollapsed = !navbarCollapsed" 
           [attr.aria-expanded]="!navbarCollapsed" aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation"> 
     <span class="navbar-toggler-icon"></span> 
   </button> 
 
   <div class="navbar-collapse collapse" [ngbCollapse]="navbarCollapsed" id="navbarContent">
-    <div class="input-group py-1 px-2 px-md-0 searchbar">
+    <div class="input-group py-1 px-2 px-sm-0 searchbar">
 <!--       <div class="input-group-prepend">
         <span class="input-group-text" id="search-addon">
           <img id="searchglyph" src="assets/images/search.svg"/>
@@ -28,9 +28,7 @@
         </a>
       </li>
       <li class="nav-item my-1">
-        <a href="{{userSignInPath()}}" class="nav-link" >
-          <span class="theme-text">Log In</span>
-        </a>
+        <nav-user></nav-user>
       </li>
       <li class="nav-item my-1">
         <a class="nav-link" [routerLink]="['/schedules']">

--- a/src/app/header/component.html
+++ b/src/app/header/component.html
@@ -1,63 +1,6 @@
-<!-- <nav id="headerbar">
-  <table id="navtable">
-    <tr>
-      <td class="sidelink" id="page-title">
-        <a [routerLink]="['/']">YACS <span class="sub">beta</span></a>
-      <td>
-        <span id="searchcontainer">
-          <img id="searchglyph" src="assets/images/search.svg"/>
-          <input #term id="searchbar" type="text" 
-          [ngbTypeahead]="searchAhead" (selectItem)="selectedCourse($event)"
-          placeholder="Search Fall 2017" (keyup.enter)="search(term.value)"
-          [focusFirst]="false"/>
-        </span>
-      </td>
-      <td class="sidelink" id="schedule-btn">
-        <a [routerLink]="['/courses']" [queryParams]="{ tags: ['featured'] }">Topics<span class = "tiny">&nbsp; new!</span></a>
-      </td>
-      <td class="sidelink" id="schedule-btn">
-        <a [routerLink]="['/schedules']">Schedule</a>
-      </td>
-    </tr>
-  </table>
-</nav> -->
-
-<!-- 
-<nav class="navbar navbar-light fixed-top">
-  <a class="navbar-brand" [routerLink]="['/']">
-    YACS <span class="sub">beta</span>
-  </a>
-  <button class="navbar-toggler navbar-toggler-right" type="button" (click)="navbarCollapsed = !navbarCollapsed"
-          [attr.aria-expanded]="!navbarCollapsed" aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">
-    <span class="navbar-toggler-icon"></span>
-  </button>
-
-  <div class="navbar-collapse" [ngbCollapse]="navbarCollapsed" id="navbarContent">
-    <ul class="navbar-nav mr-auto">
-      <li class="nav-item">
-        <a class="nav-link" [routerLink]="['/getting-started']" (click)="navbarCollapsed = true">Getting Started</a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" [routerLink]="['/components']" (click)="navbarCollapsed = true">Components</a>
-      </li>
-      <li class="nav-item d-lg-none" *ngFor="let component of components" [routerLinkActive]="['active']">
-        <a class="nav-link" [routerLink]="['/components', component.toLowerCase()]" (click)="navbarCollapsed = true">{{ component }}</a>
-      </li>
-    </ul>
-    <form class="form-inline">
-        <div class="input-group">
-          <div class="input-group-prepend">
-            <span class="input-group-text" id="search-addon">Q</span>
-          </div>
-          <input type="text" class="form-control" placeholder="Search" aria-label="Search" aria-describedby="search-addon">
-        </div>
-      </form>
-  </div>
-</nav> -->
-
-<header class="navbar navbar-light fixed-top navbar-expand-lg justify-content-center bg-light"> 
-  <a class="navbar-brand" [routerLink]="['/']" (click)="navbarCollapsed = true">
-    YACS <span class="small">beta</span>
+<header class="navbar navbar-light fixed-top navbar-expand-lg justify-content-stretch bg-light"> 
+  <a class="navbar-brand yacs-link" [routerLink]="['/']" (click)="navbarCollapsed = true">
+    <span class="theme-text theme-text-heavy">Yacs</span>
   </a>
 
   <button class="navbar-toggler navbar-toggler-right" type="button" (click)="navbarCollapsed = !navbarCollapsed" 
@@ -65,71 +8,42 @@
     <span class="navbar-toggler-icon"></span> 
   </button> 
   
-  <div class="navbar-collapse collapse justify-content-between align-items-center w-100" [ngbCollapse]="navbarCollapsed" id="navbarContent"> 
+  <div class="navbar-collapse collapse align-items-center w-100" [ngbCollapse]="navbarCollapsed" id="navbarContent"> 
     <ul class="navbar-nav mr-auto mx-auto text-center"> 
       <li class="nav-item"> 
-        <form class="form-inline">
+        <form class="form-inline searchbar">
           <div class="input-group">
             <div class="input-group-prepend">
               <span class="input-group-text" id="search-addon">
                 <img id="searchglyph" src="assets/images/search.svg"/>
               </span>
             </div>
-            <input type="text" class="form-control" placeholder="Search Yacs" aria-label="Search" aria-describedby="search-addon">
+            <input type="text" class="form-control" placeholder="Search Yacs" aria-label="Search" aria-describedby="search-addon"
+                   [ngbTypeahead]="searchAhead" [focusFirst]="false" (selectItem)="selectedCourse($event)" #term
+                   (keyup.enter)="search(term.value)"/>
           </div>
         </form>
       </li>
     </ul>
+
     <ul class="nav navbar-nav">
-        <li class="nav-item">
-            <a [routerLink]="['/courses']" [queryParams]="{ tags: ['featured'] }">Topics<span class = "small">new!</span></a>
-        </li>
-        <li class="nav-item"><a [routerLink]="['/schedules']">Schedule</a></li>
+      <li class="nav-item">
+        <a class="nav-link" [routerLink]="['/courses']" [queryParams]="{ tags: ['featured'] }">
+          <span class="theme-text">Topics <span class = "small">new!</span></span>
+        </a>
+      </li>
+      <li class="nav-item">
+        <a href="{{userSignInPath()}}" class="nav-link" >
+          <span class="theme-text">Log In</span>
+        </a>
+      </li>
+    </ul>
+    <ul class="nav navbar-nav">
+      <li class="nav-item">
+        <a class="nav-link" [routerLink]="['/schedules']">
+          <span class="theme-text theme-text-heavy">Schedule</span>
+        </a>
+      </li>
     </ul>
   </div>
-
-
-  <!-- <a class="navbar-text large text-truncate mt-1 w-100 text-right"><strong>Log In</strong></a>
-  <a class="navbar-text large text-truncate mt-1 w-100 text-right"><strong>Schedule</strong></a>
-   -->
-  <!-- <div class="navbar-collapse collapse justify-content-between align-items-center w-100" [ngbCollapse]="navbarCollapsed" id="navbarContent">
-      <ul class="navbar-nav mx-auto text-center">
-          <li class="nav-item active">
-              <a class="nav-link" href="#">Link <span class="sr-only">Home</span></a>
-          </li>
-          <li class="nav-item">
-              <a class="nav-link" href="//codeply.com">Codeply</a>
-          </li>
-          <li class="nav-item">
-              <a class="nav-link" href="#">Link</a> 
-          </li>
-      </ul>
-    </div> -->
-
-
-       <!-- <li class="nav-item" [routerLinkActive]="['active']"> 
-         <a class="nav-link" [routerLink]="['/components']" (click)="navbarCollapsed = true">Components</a> 
-       </li> 
-       <li class="nav-item d-lg-none" *ngFor="let component of components" [routerLinkActive]="['active']"> 
-         <a class="nav-link" [routerLink]="['/components', component.toLowerCase()]" (click)="navbarCollapsed = true">{{ component }}</a> 
-       </li> 
-     </ul> 
-  
-     <span class="github-buttons d-none d-lg-inline"> 
-       <a class="github-button" 
-          href="https://github.com/ng-bootstrap/ng-bootstrap" 
-          target="_blank" 
-          data-style="mega" 
-          data-count-href="/ng-bootstrap/ng-bootstrap/stargazers" 
-          data-count-api="/repos/ng-bootstrap/ng-bootstrap#stargazers_count" 
-          data-count-aria-label="# stargazers on GitHub" 
-          aria-label="Star ng-bootstrap/ng-bootstrap on GitHub">Star</a> 
-       <a href="https://twitter.com/intent/tweet?button_hashtag=ngbootstrap" 
-          class="twitter-hashtag-button" 
-          data-size="large" 
-          data-text="I&#39;m checking out ng-bootstrap, THE Angular UI framework for Bootstrap CSS" 
-          data-url="https://ng-bootstrap.github.io" 
-          data-show-count="true">Tweet #ngbootstrap</a> 
-     </span>  -->
-   <!-- </div>  -->
- </header> 
+</header>

--- a/src/app/header/component.html
+++ b/src/app/header/component.html
@@ -1,4 +1,4 @@
-<header class="navbar navbar-light fixed-top navbar-expand-lg justify-content-stretch bg-light"> 
+<header class="navbar fixed-top navbar-expand-md justify-content-stretch"> 
   <a class="navbar-brand yacs-link" [routerLink]="['/']" (click)="navbarCollapsed = true">
     <span class="theme-text theme-text-heavy">Yacs</span>
   </a>

--- a/src/app/header/component.html
+++ b/src/app/header/component.html
@@ -1,40 +1,42 @@
 <nav class="navbar navbar-custom fixed-top navbar-expand-sm flex-wrap2 flex-md-nowrap p-0">
-  <a class="navbar-brand col-auto mr-0 yacs-link" [routerLink]="['/']" (click)="navbarCollapsed = true">
-    <span class="theme-text theme-text-heavy">Yacs</span>
-  </a>
+  <div class="container">
+    <a class="navbar-brand col-auto mr-0 yacs-link" [routerLink]="['/']" (click)="navbarCollapsed = true">
+      <span class="theme-text theme-text-heavy">Yacs</span>
+    </a>
 
-  <button class="navbar-toggler d-sm-none mt-1 mr-0" type="button" (click)="navbarCollapsed = !navbarCollapsed" 
-          [attr.aria-expanded]="!navbarCollapsed" aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation"> 
-    <span class="navbar-toggler-icon"></span> 
-  </button> 
+    <button class="navbar-toggler d-sm-none mt-1 mr-0" type="button" (click)="navbarCollapsed = !navbarCollapsed" 
+            [attr.aria-expanded]="!navbarCollapsed" aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation"> 
+      <span class="navbar-toggler-icon"></span> 
+    </button> 
 
-  <div class="navbar-collapse collapse" [ngbCollapse]="navbarCollapsed" id="navbarContent">
-    <div class="input-group py-1 px-2 px-sm-0 searchbar">
-<!--       <div class="input-group-prepend">
-        <span class="input-group-text" id="search-addon">
-          <img id="searchglyph" src="assets/images/search.svg"/>
-        </span>
-      </div> -->
-      <input type="text" class="form-control" placeholder="Search Yacs" aria-label="Search" aria-describedby="search-addon"
-             [ngbTypeahead]="searchAhead" [focusFirst]="false"
-             (selectItem)="selectedCourse($event)" #term
-             (keyup.enter)="search(term.value)"/>
+    <div class="navbar-collapse collapse" [ngbCollapse]="navbarCollapsed" id="navbarContent">
+      <div class="input-group py-1 px-2 px-sm-0 searchbar">
+  <!--       <div class="input-group-prepend">
+          <span class="input-group-text" id="search-addon">
+            <img id="searchglyph" src="assets/images/search.svg"/>
+          </span>
+        </div> -->
+        <input type="text" class="form-control" placeholder="Search Yacs" aria-label="Search" aria-describedby="search-addon"
+               [ngbTypeahead]="searchAhead" [focusFirst]="false"
+               (selectItem)="selectedCourse($event)" #term
+               (keyup.enter)="search(term.value)"/>
+      </div>
+
+      <ul class="nav navbar-nav text-nowrap pl-2 pr-3">
+        <li class="nav-item my-1">
+          <a class="nav-link" [routerLink]="['/courses']" [queryParams]="{ tags: ['featured'] }">
+            <span class="theme-text">Topics</span>
+          </a>
+        </li>
+        <li class="nav-item my-1">
+          <nav-user></nav-user>
+        </li>
+        <li class="nav-item my-1">
+          <a class="nav-link" [routerLink]="['/schedules']">
+            <span class="theme-text theme-text-heavy">Schedule</span>
+          </a>
+        </li>
+      </ul>
     </div>
-
-    <ul class="nav navbar-nav text-nowrap pl-2 pr-3">
-      <li class="nav-item my-1">
-        <a class="nav-link" [routerLink]="['/courses']" [queryParams]="{ tags: ['featured'] }">
-          <span class="theme-text">Topics</span>
-        </a>
-      </li>
-      <li class="nav-item my-1">
-        <nav-user></nav-user>
-      </li>
-      <li class="nav-item my-1">
-        <a class="nav-link" [routerLink]="['/schedules']">
-          <span class="theme-text theme-text-heavy">Schedule</span>
-        </a>
-      </li>
-    </ul>
   </div>
 </nav>

--- a/src/app/header/component.html
+++ b/src/app/header/component.html
@@ -1,49 +1,42 @@
-<header class="navbar fixed-top navbar-expand-md justify-content-stretch"> 
-  <a class="navbar-brand yacs-link" [routerLink]="['/']" (click)="navbarCollapsed = true">
+<nav class="navbar navbar-custom fixed-top navbar-expand-md flex-wrap2 flex-md-nowrap p-0">
+  <a class="navbar-brand col-auto mr-0 yacs-link" [routerLink]="['/']" (click)="navbarCollapsed = true">
     <span class="theme-text theme-text-heavy">Yacs</span>
   </a>
 
-  <button class="navbar-toggler navbar-toggler-right" type="button" (click)="navbarCollapsed = !navbarCollapsed" 
+  <button class="navbar-toggler d-md-none mt-1 mr-0" type="button" (click)="navbarCollapsed = !navbarCollapsed" 
           [attr.aria-expanded]="!navbarCollapsed" aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation"> 
     <span class="navbar-toggler-icon"></span> 
   </button> 
-  
-  <div class="navbar-collapse collapse align-items-center w-100" [ngbCollapse]="navbarCollapsed" id="navbarContent"> 
-    <ul class="navbar-nav mr-auto mx-auto text-center"> 
-      <li class="nav-item"> 
-        <form class="form-inline searchbar">
-          <div class="input-group">
-            <div class="input-group-prepend">
-              <span class="input-group-text" id="search-addon">
-                <img id="searchglyph" src="assets/images/search.svg"/>
-              </span>
-            </div>
-            <input type="text" class="form-control" placeholder="Search Yacs" aria-label="Search" aria-describedby="search-addon"
-                   [ngbTypeahead]="searchAhead" [focusFirst]="false" (selectItem)="selectedCourse($event)" #term
-                   (keyup.enter)="search(term.value)"/>
-          </div>
-        </form>
-      </li>
-    </ul>
 
-    <ul class="nav navbar-nav">
-      <li class="nav-item">
+  <div class="navbar-collapse collapse" [ngbCollapse]="navbarCollapsed" id="navbarContent">
+    <div class="input-group py-1 px-2 px-md-0 searchbar">
+<!--       <div class="input-group-prepend">
+        <span class="input-group-text" id="search-addon">
+          <img id="searchglyph" src="assets/images/search.svg"/>
+        </span>
+      </div> -->
+      <input type="text" class="form-control" placeholder="Search Yacs" aria-label="Search" aria-describedby="search-addon"
+             [ngbTypeahead]="searchAhead" [focusFirst]="false"
+             (selectItem)="selectedCourse($event)" #term
+             (keyup.enter)="search(term.value)"/>
+    </div>
+
+    <ul class="nav navbar-nav text-nowrap pl-2 pr-3">
+      <li class="nav-item my-1">
         <a class="nav-link" [routerLink]="['/courses']" [queryParams]="{ tags: ['featured'] }">
-          <span class="theme-text">Topics <span class = "small">new!</span></span>
+          <span class="theme-text">Topics</span>
         </a>
       </li>
-      <li class="nav-item">
+      <li class="nav-item my-1">
         <a href="{{userSignInPath()}}" class="nav-link" >
           <span class="theme-text">Log In</span>
         </a>
       </li>
-    </ul>
-    <ul class="nav navbar-nav">
-      <li class="nav-item">
+      <li class="nav-item my-1">
         <a class="nav-link" [routerLink]="['/schedules']">
           <span class="theme-text theme-text-heavy">Schedule</span>
         </a>
       </li>
     </ul>
   </div>
-</header>
+</nav>

--- a/src/app/header/component.html
+++ b/src/app/header/component.html
@@ -1,4 +1,4 @@
-<nav id="headerbar">
+<!-- <nav id="headerbar">
   <table id="navtable">
     <tr>
       <td class="sidelink" id="page-title">
@@ -20,4 +20,105 @@
       </td>
     </tr>
   </table>
-</nav>
+</nav> -->
+
+<!-- 
+<nav class="navbar navbar-light fixed-top">
+  <a class="navbar-brand" [routerLink]="['/']">
+    YACS <span class="sub">beta</span>
+  </a>
+  <button class="navbar-toggler navbar-toggler-right" type="button" (click)="navbarCollapsed = !navbarCollapsed"
+          [attr.aria-expanded]="!navbarCollapsed" aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+
+  <div class="navbar-collapse" [ngbCollapse]="navbarCollapsed" id="navbarContent">
+    <ul class="navbar-nav mr-auto">
+      <li class="nav-item">
+        <a class="nav-link" [routerLink]="['/getting-started']" (click)="navbarCollapsed = true">Getting Started</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" [routerLink]="['/components']" (click)="navbarCollapsed = true">Components</a>
+      </li>
+      <li class="nav-item d-lg-none" *ngFor="let component of components" [routerLinkActive]="['active']">
+        <a class="nav-link" [routerLink]="['/components', component.toLowerCase()]" (click)="navbarCollapsed = true">{{ component }}</a>
+      </li>
+    </ul>
+    <form class="form-inline">
+        <div class="input-group">
+          <div class="input-group-prepend">
+            <span class="input-group-text" id="search-addon">Q</span>
+          </div>
+          <input type="text" class="form-control" placeholder="Search" aria-label="Search" aria-describedby="search-addon">
+        </div>
+      </form>
+  </div>
+</nav> -->
+
+<header class="navbar navbar-light fixed-top navbar-expand-lg justify-content-center bg-light"> 
+  <a class="navbar-brand" [routerLink]="['/']" (click)="navbarCollapsed = true">
+    YACS <span class="sub">beta</span>
+  </a>
+
+  <button class="navbar-toggler navbar-toggler-right" type="button" (click)="navbarCollapsed = !navbarCollapsed" 
+          [attr.aria-expanded]="!navbarCollapsed" aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation"> 
+    <span class="navbar-toggler-icon"></span> 
+  </button> 
+  
+  <div class="navbar-collapse collapse justify-content-between align-items-center w-100" [ngbCollapse]="navbarCollapsed" id="navbarContent"> 
+    <ul class="navbar-nav mr-auto mx-auto text-center"> 
+      <li class="nav-item"> 
+        <form class="form-inline">
+          <div class="input-group">
+            <div class="input-group-prepend">
+                <span class="input-group-text" id="search-addon">
+                  <img id="searchglyph" src="assets/images/search.svg"/>
+                </span>
+              </div>
+              <input type="text" class="form-control" placeholder="Search Yacs" aria-label="Search" aria-describedby="search-addon">
+            </div>
+          </form>
+      </li>
+    </ul>
+  </div>
+  <!-- <div class="navbar-collapse collapse justify-content-between align-items-center w-100" [ngbCollapse]="navbarCollapsed" id="navbarContent">
+      <ul class="navbar-nav mx-auto text-center">
+          <li class="nav-item active">
+              <a class="nav-link" href="#">Link <span class="sr-only">Home</span></a>
+          </li>
+          <li class="nav-item">
+              <a class="nav-link" href="//codeply.com">Codeply</a>
+          </li>
+          <li class="nav-item">
+              <a class="nav-link" href="#">Link</a> 
+          </li>
+      </ul>
+    </div> -->
+
+
+       <!-- <li class="nav-item" [routerLinkActive]="['active']"> 
+         <a class="nav-link" [routerLink]="['/components']" (click)="navbarCollapsed = true">Components</a> 
+       </li> 
+       <li class="nav-item d-lg-none" *ngFor="let component of components" [routerLinkActive]="['active']"> 
+         <a class="nav-link" [routerLink]="['/components', component.toLowerCase()]" (click)="navbarCollapsed = true">{{ component }}</a> 
+       </li> 
+     </ul> 
+  
+     <span class="github-buttons d-none d-lg-inline"> 
+       <a class="github-button" 
+          href="https://github.com/ng-bootstrap/ng-bootstrap" 
+          target="_blank" 
+          data-style="mega" 
+          data-count-href="/ng-bootstrap/ng-bootstrap/stargazers" 
+          data-count-api="/repos/ng-bootstrap/ng-bootstrap#stargazers_count" 
+          data-count-aria-label="# stargazers on GitHub" 
+          aria-label="Star ng-bootstrap/ng-bootstrap on GitHub">Star</a> 
+       <a href="https://twitter.com/intent/tweet?button_hashtag=ngbootstrap" 
+          class="twitter-hashtag-button" 
+          data-size="large" 
+          data-text="I&#39;m checking out ng-bootstrap, THE Angular UI framework for Bootstrap CSS" 
+          data-url="https://ng-bootstrap.github.io" 
+          data-show-count="true">Tweet #ngbootstrap</a> 
+     </span>  -->
+   <!-- </div>  -->
+ </header> 

--- a/src/app/header/component.html
+++ b/src/app/header/component.html
@@ -57,7 +57,7 @@
 
 <header class="navbar navbar-light fixed-top navbar-expand-lg justify-content-center bg-light"> 
   <a class="navbar-brand" [routerLink]="['/']" (click)="navbarCollapsed = true">
-    YACS <span class="sub">beta</span>
+    YACS <span class="small">beta</span>
   </a>
 
   <button class="navbar-toggler navbar-toggler-right" type="button" (click)="navbarCollapsed = !navbarCollapsed" 
@@ -71,16 +71,27 @@
         <form class="form-inline">
           <div class="input-group">
             <div class="input-group-prepend">
-                <span class="input-group-text" id="search-addon">
-                  <img id="searchglyph" src="assets/images/search.svg"/>
-                </span>
-              </div>
-              <input type="text" class="form-control" placeholder="Search Yacs" aria-label="Search" aria-describedby="search-addon">
+              <span class="input-group-text" id="search-addon">
+                <img id="searchglyph" src="assets/images/search.svg"/>
+              </span>
             </div>
-          </form>
+            <input type="text" class="form-control" placeholder="Search Yacs" aria-label="Search" aria-describedby="search-addon">
+          </div>
+        </form>
       </li>
     </ul>
+    <ul class="nav navbar-nav">
+        <li class="nav-item">
+            <a [routerLink]="['/courses']" [queryParams]="{ tags: ['featured'] }">Topics<span class = "small">new!</span></a>
+        </li>
+        <li class="nav-item"><a [routerLink]="['/schedules']">Schedule</a></li>
+    </ul>
   </div>
+
+
+  <!-- <a class="navbar-text large text-truncate mt-1 w-100 text-right"><strong>Log In</strong></a>
+  <a class="navbar-text large text-truncate mt-1 w-100 text-right"><strong>Schedule</strong></a>
+   -->
   <!-- <div class="navbar-collapse collapse justify-content-between align-items-center w-100" [ngbCollapse]="navbarCollapsed" id="navbarContent">
       <ul class="navbar-nav mx-auto text-center">
           <li class="nav-item active">

--- a/src/app/header/component.scss
+++ b/src/app/header/component.scss
@@ -81,10 +81,43 @@
 //     }
 // }
 
+.theme-text {
+  text-decoration: none;
+  color: $yacs_bgs;
+}
+
+.theme-text-heavy {
+  font-weight: bolder;
+  font-size: larger;
+}
+
+.navbar-brand {
+
+}
+
+form.searchbar {
+  input {
+    border-left: none;
+    border-color: $yacs_bgs;
+    box-shadow: none;
+  }
+
+  .input-group-prepend * {
+    border-right: none;
+    border-color: $yacs_bgs;
+  }
+}
+
+input::placeholder {
+  color: $yacs_bgs;
+  font-style: italic;
+  font-weight: lighter;
+}
+
 #searchglyph {
-    height: 1em;
-    vertical-align: sub;
-    padding: 0.1em;
+  height: 1.5em;
+  vertical-align: sub;
+  padding: 0.1em;
 }
 
 // #schedule-btn {

--- a/src/app/header/component.scss
+++ b/src/app/header/component.scss
@@ -81,9 +81,13 @@
 //     }
 // }
 
+.navbar {
+  background-color: $yacs_bgs;
+}
+
 .theme-text {
   text-decoration: none;
-  color: $yacs_bgs;
+  color: #ffffff;
 }
 
 .theme-text-heavy {
@@ -105,6 +109,7 @@ form.searchbar {
   .input-group-prepend * {
     border-right: none;
     border-color: $yacs_bgs;
+    background-color: #ffffff;
   }
 }
 

--- a/src/app/header/component.scss
+++ b/src/app/header/component.scss
@@ -4,7 +4,7 @@
   background-color: $yacs_bgs;
   padding-top: 0px;
   padding-bottom: 0px;
-  @media(min-width: 768px) {
+  @media(min-width: 576px) {
     height: $header_height;
   }
 
@@ -15,19 +15,6 @@
   .navbar-toggler-icon {
     background-image: url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='rgba(255, 255, 255, 1.0)' stroke-width='3' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/%3E%3C/svg%3E");
   }
-}
-
-.theme-text {
-  color: #ffffff;
-}
-
-.theme-text-heavy {
-  font-weight: bolder;
-  font-size: larger;
-}
-
-.navbar-brand {
-
 }
 
 .searchbar {
@@ -44,14 +31,6 @@
     border-color: $yacs_bgs;
     background-color: #ffffff;
   }
-}
-
-.dropdown-menu {
-  width: 100% !important;
-  left: 0px !important;
-  border-radius: 2px;
-  margin-top: 0px;
-  padding-top: 0px;
 }
 
 input::placeholder {

--- a/src/app/header/component.scss
+++ b/src/app/header/component.scss
@@ -8,6 +8,10 @@
     height: $header_height;
   }
 
+  .container {
+    max-width: 1200px;
+  }
+
   .navbar-nav {
     flex-wrap: nowrap;
   }

--- a/src/app/header/component.scss
+++ b/src/app/header/component.scss
@@ -1,85 +1,85 @@
 @import "../../_vars.scss";
 
-nav#headerbar {
-    width:100%;
-    height:50px;
-    position:fixed;
-    z-index: 1;
-    font-family: $font;  
-    font-weight: 300;  
-    background-color: $yacs_bgs;
-    white-space: nowrap;
-}
+// nav#headerbar {
+//     width:100%;
+//     height:50px;
+//     position:fixed;
+//     z-index: 1;
+//     font-family: $font;  
+//     font-weight: 300;  
+//     background-color: $yacs_bgs;
+//     white-space: nowrap;
+// }
 
-table#navtable {
-    width:100%;
-    height:100%;
-    border-collapse:collapse;
-    td {
-        text-align:center;
-        vertical-align:middle;
-    }
-}
+// table#navtable {
+//     width:100%;
+//     height:100%;
+//     border-collapse:collapse;
+//     td {
+//         text-align:center;
+//         vertical-align:middle;
+//     }
+// }
 
-.sidelink {
-    width:160px;
-    cursor:pointer;
-    a {
-        color: #FFFFFF;
-        text-decoration:none;
-    } 
-}
+// .sidelink {
+//     width:160px;
+//     cursor:pointer;
+//     a {
+//         color: #FFFFFF;
+//         text-decoration:none;
+//     } 
+// }
 
-#page-title {
-    font-size: 35px;
-    span.sub{
-        font-size:16px;
-    }
-}
+// #page-title {
+//     font-size: 35px;
+//     span.sub{
+//         font-size:16px;
+//     }
+// }
 
-span.tiny{
-    font-size: 11px;
-}
+// span.tiny{
+//     font-size: 11px;
+// }
 
-#search {
-    margin:auto;
-}
+// #search {
+//     margin:auto;
+// }
 
-#searchcontainer {
-    font-family: $font;
-    font-weight: 300;
-    font-size: 18px;
-    color: white;
-    background-color: #d57f7f;
-    border-radius: 2px;
-    width: 100%;
-    padding: 3px 4px;
-    margin:auto;
+// #searchcontainer {
+//     font-family: $font;
+//     font-weight: 300;
+//     font-size: 18px;
+//     color: white;
+//     background-color: #d57f7f;
+//     border-radius: 2px;
+//     width: 100%;
+//     padding: 3px 4px;
+//     margin:auto;
 
-}
+// }
 
-#searchbar {
-    font-family: $font;
-    font-weight: 300;
-    font-size: 18px;
-    max-width: 20em;
-    border: none;
-    width: 100%;
-    background-color: inherit;
-    color: inherit;
-    outline: none;
-    &::-ms-input-placeholder {
-        color: #FFFFFF;
+// #searchbar {
+//     font-family: $font;
+//     font-weight: 300;
+//     font-size: 18px;
+//     max-width: 20em;
+//     border: none;
+//     width: 100%;
+//     background-color: inherit;
+//     color: inherit;
+//     outline: none;
+//     &::-ms-input-placeholder {
+//         color: #FFFFFF;
 
-    }
-    &::-moz-placeholder{
-        color: #FFFFFF;
+//     }
+//     &::-moz-placeholder{
+//         color: #FFFFFF;
 
-    } 
-    &::-webkit-input-placeholder {
-        color: #FFFFFF;
-    }
-}
+//     } 
+//     &::-webkit-input-placeholder {
+//         color: #FFFFFF;
+//     }
+// }
 
 #searchglyph {
     height: 1em;
@@ -87,6 +87,6 @@ span.tiny{
     padding: 0.1em;
 }
 
-#schedule-btn {
-    font-size:22px;
-}
+// #schedule-btn {
+//     font-size:22px;
+// }

--- a/src/app/header/component.scss
+++ b/src/app/header/component.scss
@@ -1,92 +1,23 @@
 @import "../../_vars.scss";
 
-// nav#headerbar {
-//     width:100%;
-//     height:50px;
-//     position:fixed;
-//     z-index: 1;
-//     font-family: $font;  
-//     font-weight: 300;  
-//     background-color: $yacs_bgs;
-//     white-space: nowrap;
-// }
-
-// table#navtable {
-//     width:100%;
-//     height:100%;
-//     border-collapse:collapse;
-//     td {
-//         text-align:center;
-//         vertical-align:middle;
-//     }
-// }
-
-// .sidelink {
-//     width:160px;
-//     cursor:pointer;
-//     a {
-//         color: #FFFFFF;
-//         text-decoration:none;
-//     } 
-// }
-
-// #page-title {
-//     font-size: 35px;
-//     span.sub{
-//         font-size:16px;
-//     }
-// }
-
-// span.tiny{
-//     font-size: 11px;
-// }
-
-// #search {
-//     margin:auto;
-// }
-
-// #searchcontainer {
-//     font-family: $font;
-//     font-weight: 300;
-//     font-size: 18px;
-//     color: white;
-//     background-color: #d57f7f;
-//     border-radius: 2px;
-//     width: 100%;
-//     padding: 3px 4px;
-//     margin:auto;
-
-// }
-
-// #searchbar {
-//     font-family: $font;
-//     font-weight: 300;
-//     font-size: 18px;
-//     max-width: 20em;
-//     border: none;
-//     width: 100%;
-//     background-color: inherit;
-//     color: inherit;
-//     outline: none;
-//     &::-ms-input-placeholder {
-//         color: #FFFFFF;
-
-//     }
-//     &::-moz-placeholder{
-//         color: #FFFFFF;
-
-//     } 
-//     &::-webkit-input-placeholder {
-//         color: #FFFFFF;
-//     }
-// }
-
-.navbar {
+.navbar-custom {
   background-color: $yacs_bgs;
+  padding-top: 0px;
+  padding-bottom: 0px;
+  @media(min-width: 768px) {
+    height: $header_height;
+  }
+
+  .navbar-nav {
+    flex-wrap: nowrap;
+  }
+
+  .navbar-toggler-icon {
+    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 30 30' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='rgba(255, 255, 255, 1.0)' stroke-width='3' stroke-linecap='round' stroke-miterlimit='10' d='M4 7h22M4 15h22M4 23h22'/%3E%3C/svg%3E");
+  }
 }
 
 .theme-text {
-  text-decoration: none;
   color: #ffffff;
 }
 
@@ -99,11 +30,13 @@
 
 }
 
-form.searchbar {
+.searchbar {
   input {
-    border-left: none;
-    border-color: $yacs_bgs;
+    /*border-left: none;*/
+    border-radius: 2px;
+    border-color: #d57f7f;
     box-shadow: none;
+
   }
 
   .input-group-prepend * {
@@ -111,6 +44,14 @@ form.searchbar {
     border-color: $yacs_bgs;
     background-color: #ffffff;
   }
+}
+
+.dropdown-menu {
+  width: 100% !important;
+  left: 0px !important;
+  border-radius: 2px;
+  margin-top: 0px;
+  padding-top: 0px;
 }
 
 input::placeholder {
@@ -124,7 +65,3 @@ input::placeholder {
   vertical-align: sub;
   padding: 0.1em;
 }
-
-// #schedule-btn {
-//     font-size:22px;
-// }

--- a/src/app/header/component.ts
+++ b/src/app/header/component.ts
@@ -21,7 +21,7 @@ export class HeaderComponent {
   navbarCollapsed: boolean = true;
 
   constructor(
-    private router: Router, 
+    private router: Router,
     private yacsService: YacsService) {}
 
   //keyup.enter generic search
@@ -62,6 +62,10 @@ export class HeaderComponent {
         name: $event.item
       }});
     this.dropDownSelected = true;
+  }
+
+  userSignInPath (): string {
+    return `/users/sign_in?referer=${document.location}`;
   }
 
 }

--- a/src/app/header/component.ts
+++ b/src/app/header/component.ts
@@ -17,7 +17,8 @@ import 'rxjs/add/operator/distinctUntilChanged';
 export class HeaderComponent {
 
   //flag to stop keyup.enter from doing normal search when drop down is used
-  dropDownSelected: boolean = false;                  
+  dropDownSelected: boolean = false;
+  navbarCollapsed: boolean = true;
 
   constructor(
     private router: Router, 

--- a/src/app/header/component.ts
+++ b/src/app/header/component.ts
@@ -63,9 +63,4 @@ export class HeaderComponent {
       }});
     this.dropDownSelected = true;
   }
-
-  userSignInPath (): string {
-    return `/users/sign_in?referer=${document.location}`;
-  }
-
 }

--- a/src/app/header/nav-user/component.html
+++ b/src/app/header/nav-user/component.html
@@ -1,0 +1,10 @@
+<span *ngIf="!isLoggedIn()">
+  <a href="{{userSignInPath()}}" class="nav-link">
+    <span class="theme-text">Log In</span>
+  </a>
+</span>
+<span *ngIf="isLoggedIn()">
+  <a href="{{userSignOutPath()}}" class="nav-link">
+    <span class="theme-text">Log Out</span>
+  </a>
+</span>

--- a/src/app/header/nav-user/component.spec.ts
+++ b/src/app/header/nav-user/component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NavUserComponent } from './nav-user.component';
+
+describe('NavUserComponent', () => {
+  let component: NavUserComponent;
+  let fixture: ComponentFixture<NavUserComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ NavUserComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NavUserComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/header/nav-user/component.ts
+++ b/src/app/header/nav-user/component.ts
@@ -1,0 +1,28 @@
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { UserService } from '../../services/user.service';
+
+@Component({
+  selector: 'nav-user',
+  templateUrl: './component.html',
+  styleUrls: ['./component.scss']
+})
+export class NavUserComponent implements OnInit {
+
+  constructor (private router: Router,
+               private userService: UserService) { }
+
+  ngOnInit () { }
+
+  isLoggedIn () : boolean {
+    return this.userService.isLoggedIn();
+  }
+
+  userSignInPath () : string {
+    return `/users/sign_in?referer=${document.location}`;
+  }
+
+  userSignOutPath () : string {
+    return "/users/sign_out";
+  }
+}

--- a/src/app/models/user.model.ts
+++ b/src/app/models/user.model.ts
@@ -1,0 +1,4 @@
+export class User {
+  id: number;
+  email: string;
+}

--- a/src/app/notice-bar/component.scss
+++ b/src/app/notice-bar/component.scss
@@ -1,7 +1,7 @@
 @import "../../_vars.scss";
 
 div#noticebar {
-    padding-top: 50px;
+    padding-top: $header_height;
     position: fixed;
     width: 100%;
 }

--- a/src/app/school-list/component.scss
+++ b/src/app/school-list/component.scss
@@ -1,17 +1,4 @@
 school {
-    display:inline-block;
-    width: 475px;
-    padding: 0px 1px;
-}
-
-noscript {
-    color:#933;
-    font-weight:bold;
-    font-size:150%;
-}
-
-div#bottomtext {
-    display:block;
-    color:#afafaf;
-    margin-bottom:8px;
+  display: inline-block;
+  width: 100%;
 }

--- a/src/app/services/user.service.spec.ts
+++ b/src/app/services/user.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { UserService } from './user.service';
+
+describe('UserService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [UserService]
+    });
+  });
+
+  it('should be created', inject([UserService], (service: UserService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { User } from '../models/user.model';
+
+@Injectable()
+export class UserService {
+
+  constructor () { }
+
+  public isLoggedIn () : boolean {
+    return !!this.getUser();
+  }
+
+  public getUser () : User {
+    return JSON.parse(this.getCookie('yacs.user'));
+  }
+
+  private getCookie (name) : string {
+    const ca = document.cookie.split(';');
+    for (let i = 0; i < ca.length; i++) {
+      let c = ca[i];
+      while (c.charAt(0) === ' ') {
+        c = c.substring(1, c.length);
+      }
+      if (c.indexOf(name + '=') === 0) {
+        const uriEncodedCookie = c.substring(name.length + 1, c.length);
+        return decodeURIComponent(uriEncodedCookie);
+      }
+    }
+    return null;
+  }
+}

--- a/src/assets/images/search.svg
+++ b/src/assets/images/search.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" fill="white"
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" fill="#C65353"
 	 width="512px" height="512px" viewBox="0 0 512 512" enable-background="new 0 0 512 512" xml:space="preserve">
 <g>
 	<path d="M501.255,414.849L379.817,313.63c-17.188,26.438-39.75,49-66.156,66.188l101.188,121.438

--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,6 @@
   <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
 </head>
 <body>
-  <app-root>Loading...</app-root>
+  <app-root><div class="loader"></div></app-root>
 </body>
 </html>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,7 +1,6 @@
 /* You can add global styles to this file, and also import other style files */
 @import "./_vars.scss";
 
-
 body {
     color: #000;
     font-family: $font;
@@ -12,7 +11,6 @@ body {
 #content {
     padding: 60px 15px 0px 15px;    
 }
-
 
 #loading {
     position:absolute;
@@ -69,12 +67,15 @@ footer {
   from {transform:rotate(0deg);}
   to {transform:rotate(360deg);}
 }
-a {
-  text-decoration: none;
-  color: #993333;
-}
+
+/* Global Bootstrap overrides go here */
 
 div.alert {
-    border: none;
-    border-radius: 0;
+  border: none;
+  border-radius: 0;
 }
+
+// .form-control:focus {
+//   outline: 0 none;
+//   box-shadow: 0 none;
+// }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -16,6 +16,15 @@ body {
     padding: 60px 15px 0px 15px;    
 }
 
+.theme-text {
+  color: #ffffff;
+}
+
+.theme-text-heavy {
+  font-weight: bolder;
+  font-size: larger;
+}
+
 #loading {
     position:absolute;
     top: 50%;
@@ -89,5 +98,14 @@ div.alert {
   left: 0px !important;
   border-radius: 2px;
   margin-top: 0px;
-  padding-top: 0px;
+  margin-bottom: 0px;
+  padding: 0px;
+}
+
+.dropdown-item {
+  padding: .25rem .75rem !important;
+}
+
+.dropdown-item.active, .dropdown-item:active {
+  background-color: #d57f7f !important;
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,6 +1,10 @@
 /* You can add global styles to this file, and also import other style files */
 @import "./_vars.scss";
 
+*:focus {
+  text-decoration: none;
+}
+
 body {
     color: #000;
     font-family: $font;
@@ -79,3 +83,11 @@ div.alert {
 //   outline: 0 none;
 //   box-shadow: 0 none;
 // }
+
+.dropdown-menu {
+  width: 100% !important;
+  left: 0px !important;
+  border-radius: 2px;
+  margin-top: 0px;
+  padding-top: 0px;
+}


### PR DESCRIPTION
In this PR we:
- Make the header responsive (it looks a lot better on desktop and on mobile now)
- Add Users service for getting user cookie
- Add conditional login / logout based on user cookie
- Change layout and style of typeahead dropdown to match the general Yacs style

We also change the layout properties of the schools view to look better on mobile along with the new header, and change some global styles to match the new layout.

This issues addresses #26 #27 and partially addresses #44 .

