### PR TITLE
Footer: "A supercalifragilisticexpialidocious"

### DIFF
--- a/src/app/footer/component.ts
+++ b/src/app/footer/component.ts
@@ -44,7 +44,8 @@ const FLAVORTEXTS: string[] = [
   'A painstakingly crafted',
   'A geothermal powered',
   'A mighty fine',
-  'A hydrophobic'
+  'A hydrophobic',
+  'A supercalifragilisticexpialidocious'
 ];
 
 @Component({


### PR DESCRIPTION
According to [Wikipedia](https://en.wikipedia.org/wiki/Supercalifragilisticexpialidocious):

> The Oxford English Dictionary estimates that the word "supercalifragilisticexpialidocious" was first attested in the 1940s.[2] The roots of the word have been defined[3] as follows: super- "above", cali- "beauty", fragilistic- "delicate", expiali- "to atone", and -docious "educable", with the sum of these parts signifying roughly **"Atoning for educability through delicate beauty."** According to the film, in which the word gained its popularity, it is defined as "something to say when you have nothing to say". However, it is commonly defined as "extraordinarily good" or "wonderful" as all references to the word in the film can be perceived as positive. Dictionary.com also notes that the word is "used as a nonsense word by children to express approval or to represent the longest word in English."[4]

...perfect for YACS :)