### PR TITLE
Added missing  target="_blank" to RCOS link

### DIFF
--- a/src/app/footer/component.html
+++ b/src/app/footer/component.html
@@ -1,7 +1,7 @@
 
 <div class="footer-column">
 	<div class="flavortext">
-	  {{flavortext}} <a href="https://rcos.io">RCOS</a> project.
+	  {{flavortext}} <a href="https://rcos.io" target="_blank">RCOS</a> project.
 	</div>
 	<a href="/about">Learn more about YACS.</a>
 </div>


### PR DESCRIPTION
Bugged me that it overrode the tab with a link from another domain. 😄